### PR TITLE
Add Datadog Serverless Azure Java Agent

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,74 @@
+name: Build and Release the Serverless Java Agent
+on:
+  push:
+    tags:
+      - "dd-serverless-java-agent-**"
+
+jobs:
+  build:
+    name: Build Serverless Java Agent
+    runs-on: ubuntu-latest
+    outputs:
+      mini-agent-version: ${{ steps.get-serverless-mini-agent.outputs.mini_agent_version }}
+    steps:
+      - run: echo ${{ github.ref_name }}
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Get Serverless Mini Agent
+        id: get-serverless-mini-agent
+        run: |
+          LIBDATADOG_RESPONSE=$(curl -s "https://api.github.com/repos/datadog/libdatadog/releases")
+          MINI_AGENT_VERSION=$(echo "$LIBDATADOG_RESPONSE" | jq -r --arg pattern "sls-v[0-9]*\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name' | sort -V | tail -n 1)
+
+          echo "Using version ${MINI_AGENT_VERSION} of mini agent"
+          echo "mini_agent_version=$(echo "$MINI_AGENT_VERSION" | jq -rR 'ltrimstr("sls-")')" >> "$GITHUB_OUTPUT"
+
+          curl --output-dir ./temp/ --create-dirs -O -s -L "https://github.com/DataDog/libdatadog/releases/download/${MINI_AGENT_VERSION}/datadog-serverless-agent.zip"
+          unzip ./temp/datadog-serverless-agent.zip -d ./temp/datadog-serverless-agent
+
+          mkdir src/main/resources
+          cp ./temp/datadog-serverless-agent/datadog-serverless-agent-linux-amd64/datadog-serverless-trace-mini-agent src/main/resources/datadog-serverless-trace-mini-agent
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: "8"
+          distribution: "zulu"
+      - name: Build dd-serverless-java-agent jar
+        run: mvn clean install
+      - name: Upload artifact for release
+        uses: actions/upload-artifact@v4
+        with:
+          name: release
+          path: target/${{ github.ref_name }}-jar-with-dependencies.jar
+  release:
+    name: Release
+    needs: [build]
+    runs-on: ubuntu-latest
+    env:
+      MINI_AGENT_VERSION: ${{ needs.build.outputs.mini-agent-version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+      - name: Rename artifacts
+        run: |
+          cp release/${{ github.ref_name }}-jar-with-dependencies.jar release/${{ github.ref_name }}.jar
+          cp release/${{ github.ref_name }}-jar-with-dependencies.jar release/dd-serverless-java-agent.jar
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: "Uses [${{ env.MINI_AGENT_VERSION }}](https://github.com/DataDog/libdatadog/releases/tag/sls-${{ env.MINI_AGENT_VERSION }}) of the Serverless Mini Agent."
+          draft: true
+          generate_release_notes: true
+          make_latest: true
+          files: |
+            release/${{ github.ref_name }}.jar
+            release/dd-serverless-java-agent.jar
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Latest
+          tag_name: download-latest
+          body: "This release tracks the latest version available, currently **${{ github.ref_name }}**."
+          files: release/dd-serverless-java-agent.jar

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,12 +1,12 @@
-name: Build and Release the Serverless Java Agent
+name: Build and Release the Serverless Azure Java Agent
 on:
   push:
     tags:
-      - "dd-serverless-java-agent-**"
+      - "dd-serverless-azure-java-agent-**"
 
 jobs:
   build:
-    name: Build Serverless Java Agent
+    name: Build Serverless Azure Java Agent
     runs-on: ubuntu-latest
     outputs:
       mini-agent-version: ${{ steps.get-serverless-mini-agent.outputs.mini_agent_version }}
@@ -33,7 +33,7 @@ jobs:
         with:
           java-version: "8"
           distribution: "zulu"
-      - name: Build dd-serverless-java-agent jar
+      - name: Build dd-serverless-azure-java-agent jar
         run: mvn clean install
       - name: Upload artifact for release
         uses: actions/upload-artifact@v4
@@ -54,7 +54,7 @@ jobs:
       - name: Rename artifacts
         run: |
           cp release/${{ github.ref_name }}-jar-with-dependencies.jar release/${{ github.ref_name }}.jar
-          cp release/${{ github.ref_name }}-jar-with-dependencies.jar release/dd-serverless-java-agent.jar
+          cp release/${{ github.ref_name }}-jar-with-dependencies.jar release/dd-serverless-azure-java-agent.jar
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
@@ -64,11 +64,11 @@ jobs:
           make_latest: true
           files: |
             release/${{ github.ref_name }}.jar
-            release/dd-serverless-java-agent.jar
+            release/dd-serverless-azure-java-agent.jar
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           name: Latest
           tag_name: download-latest
           body: "This release tracks the latest version available, currently **${{ github.ref_name }}**."
-          files: release/dd-serverless-java-agent.jar
+          files: release/dd-serverless-azure-java-agent.jar

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+datadog-serverless-trace-mini-agent
+target

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-# dd-serverless-java-agent
-Jave agent used to start the Datadog Serverless Mini Agent. Intended for use with Azure Spring Apps
+# Datadog Serverless Java Agent
+
+Java agent used to start the Datadog Serverless Mini Agent. Intended for use with [Azure Spring Apps](https://azure.microsoft.com/en-us/products/spring-apps).
+
+# Getting Started
+
+- From the latest release, download `dd-serverless-java-agent.jar` and upload it to your Azure Spring App in persistent storage.
+- Add the Datadog Serverless Java Agent and Datadog Java Tracer as Java agents to your `JVM_OPTIONS`.
+```
+-javaagent:/persistent/dd-serverless-java-agent.jar -javaagent:/persistent/dd-java-agent.jar
+```
+- Set environment variables
+* `DD_API_KEY` = `<YOUR API KEY>`
+* `DD_SITE` = `datadoghq.com`
+* `DD_SERVICE` = `<SERVICE NAME>`
+* `DD_ENV` = `<ENVIRONMENT`
+* `DD_VERSION` = `<VERSION>`
+* `DD_TRACE_TRACER_METRICS_ENABLED` = `true`
+
+# Contributing
+
+## Setting up development environment
+
+Follow the instructions in the `dd-trace-java` repo to set up your Java environment: [Setting up development environment](https://github.com/DataDog/dd-trace-java/blob/master/BUILDING.md#setting-up-development-environment).
+
+## Building the project
+
+Build the Datadog Serverless Mini Agent from [libdatadog](https://github.com/DataDog/libdatadog) and add the linux binary, `datadog-serverless-trace-mini-agent`, to `src/main/resources`.
+
+To build the project run:
+```
+mvn clean install
+```
+

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Datadog Serverless Java Agent
+# Datadog Serverless Azure Java Agent
 
 Java agent used to start the Datadog Serverless Mini Agent. Intended for use with [Azure Spring Apps](https://azure.microsoft.com/en-us/products/spring-apps).
 
 # Getting Started
 
-- From the latest release, download `dd-serverless-java-agent.jar` and upload it to your Azure Spring App in persistent storage.
-- Add the Datadog Serverless Java Agent and Datadog Java Tracer as Java agents to your `JVM_OPTIONS`.
+- From the latest release, download `dd-serverless-azure-java-agent.jar` and upload it to your Azure Spring App in persistent storage.
+- Add the Datadog Serverless Azure Java Agent and Datadog Java Tracer as Java agents to your `JVM_OPTIONS`.
 ```
--javaagent:/persistent/dd-serverless-java-agent.jar -javaagent:/persistent/dd-java-agent.jar
+-javaagent:/persistent/dd-serverless-azure-java-agent.jar -javaagent:/persistent/dd-java-agent.jar
 ```
 - Set environment variables
 * `DD_API_KEY` = `<YOUR API KEY>`

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.datadoghq.com</groupId>
+    <artifactId>dd-serverless-java-agent</artifactId>
+    <version>0.1.0</version>
+    <packaging>jar</packaging>
+    <name>Datadog Serverless Java Agent</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>2.7.18</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>datadog-serverless-trace-mini-agent</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifestEntries>
+                            <Premain-Class>com.datadog.ServerlessAgent</Premain-Class>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,10 +5,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.datadoghq.com</groupId>
-    <artifactId>dd-serverless-java-agent</artifactId>
+    <artifactId>dd-serverless-azure-java-agent</artifactId>
     <version>0.1.0</version>
     <packaging>jar</packaging>
-    <name>Datadog Serverless Java Agent</name>
+    <name>Datadog Serverless Azure Java Agent</name>
 
     <dependencies>
         <dependency>
@@ -73,7 +73,7 @@
                     </descriptorRefs>
                     <archive>
                         <manifestEntries>
-                            <Premain-Class>com.datadog.ServerlessAgent</Premain-Class>
+                            <Premain-Class>com.datadog.ServerlessAzureAgent</Premain-Class>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/src/main/java/com/datadog/ServerlessAgent.java
+++ b/src/main/java/com/datadog/ServerlessAgent.java
@@ -1,0 +1,35 @@
+package com.datadog;
+
+import java.io.File;
+import java.io.InputStream;
+import java.lang.instrument.Instrumentation;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ServerlessAgent {
+    private static final Logger log = LoggerFactory.getLogger(ServerlessAgent.class);
+    private static final String fileName = "datadog-serverless-trace-mini-agent";
+
+    public static void premain(String agentArgs, Instrumentation instrumentation) {
+        log.info("Attempting to start {}", fileName);
+
+        try (InputStream inputStream = ServerlessAgent.class.getClassLoader()
+                .getResourceAsStream(fileName)) {
+            if (inputStream == null) {
+                log.error("{} not found", fileName);
+            }
+
+            File executableFile = new File(fileName);
+            Files.copy(inputStream, executableFile.getAbsoluteFile().toPath(), StandardCopyOption.REPLACE_EXISTING);
+            executableFile.setExecutable(true);
+
+            ProcessBuilder processBuilder = new ProcessBuilder(executableFile.getAbsolutePath());
+            processBuilder.inheritIO();
+            processBuilder.start();
+        } catch (Exception e) {
+            log.error("Exception when starting {}", fileName, e);
+        }
+    }
+}

--- a/src/main/java/com/datadog/ServerlessAzureAgent.java
+++ b/src/main/java/com/datadog/ServerlessAzureAgent.java
@@ -8,14 +8,14 @@ import java.nio.file.StandardCopyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ServerlessAgent {
-    private static final Logger log = LoggerFactory.getLogger(ServerlessAgent.class);
+public class ServerlessAzureAgent {
+    private static final Logger log = LoggerFactory.getLogger(ServerlessAzureAgent.class);
     private static final String fileName = "datadog-serverless-trace-mini-agent";
 
     public static void premain(String agentArgs, Instrumentation instrumentation) {
         log.info("Attempting to start {}", fileName);
 
-        try (InputStream inputStream = ServerlessAgent.class.getClassLoader()
+        try (InputStream inputStream = ServerlessAzureAgent.class.getClassLoader()
                 .getResourceAsStream(fileName)) {
             if (inputStream == null) {
                 log.error("{} not found", fileName);


### PR DESCRIPTION
# What does this PR do?

- Adds a Java agent which starts the Datadog Serverless Mini Agent.
- Adds a Github workflow to build jar and add it to a new release when a tag with the format `dd-serverless-azure-java-agent-*` is pushed.
  * Also updates a `Latest` release which tracks the latest available release

# Motivation

Start the Datadog Serverless Mini Agent in Azure Spring Apps by adding `-javaagent:/path/to/dd-serverless-azure-java-agent.jar` to `JVM options`.

https://datadoghq.atlassian.net/browse/SVLS-5078

# Additional Notes

Relates to https://github.com/DataDog/libdatadog/pull/547

- Datadog Serverless Mini Agent binary is packaged in jar
- In `premain`
  * Copy the Mini Agent binary from the jar to a temporary file and make it executable
  * Create a process with the Mini Agent binary
  * Start Mini Agent binary process

# How to test the change?

See [README](https://github.com/DataDog/dd-serverless-azure-java-agent/blob/main/README.md)

- Java 8 ✅ 
- Java 11 ✅ 
- Java 17 ✅ 
- Java 21 ✅ 
