### PR TITLE
Build JAR with Docker

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,13 +28,10 @@ jobs:
 
           mkdir src/main/resources
           cp ./temp/datadog-serverless-agent/datadog-serverless-agent-linux-amd64/datadog-serverless-trace-mini-agent src/main/resources/datadog-serverless-trace-mini-agent
-      - name: Set up JDK 8
-        uses: actions/setup-java@v4
-        with:
-          java-version: "8"
-          distribution: "zulu"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build dd-serverless-azure-java-agent jar
-        run: mvn clean install
+        run: ./build.sh
       - name: Upload artifact for release
         uses: actions/upload-artifact@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/java/maven:8-zulu-debian10
+
+WORKDIR /app
+
+COPY . /app
+
+RUN mvn clean package

--- a/README.md
+++ b/README.md
@@ -29,6 +29,6 @@ Build the Datadog Serverless Mini Agent from [libdatadog](https://github.com/Dat
 
 To build the project run:
 ```
-mvn clean install
+./build.sh
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,10 @@
 VERSION=$(awk -F'[<>]' '/<version>/{print $3; exit}' pom.xml)
 
+mkdir -p target
+
 docker buildx build --platform linux/amd64 \
     -t datadog/build-dd-serverless-java-agent:$VERSION \
     . --load
+
 dockerId=$(docker create datadog/build-dd-serverless-java-agent:$VERSION)
 docker cp $dockerId:/app/target/dd-serverless-azure-java-agent-$VERSION-jar-with-dependencies.jar ./target/dd-serverless-azure-java-agent-$VERSION-jar-with-dependencies.jar

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+VERSION=$(awk -F'[<>]' '/<version>/{print $3; exit}' pom.xml)
+
+docker buildx build --platform linux/amd64 \
+    -t datadog/build-dd-serverless-java-agent:$VERSION \
+    . --load
+dockerId=$(docker create datadog/build-dd-serverless-java-agent:$VERSION)
+docker cp $dockerId:/app/target/dd-serverless-azure-java-agent-$VERSION-jar-with-dependencies.jar ./target/dd-serverless-azure-java-agent-$VERSION-jar-with-dependencies.jar


### PR DESCRIPTION
# What does this PR do?

Adds a script to build the JAR with Docker both locally and in CI.

# Motivation

Consistent builds for testing and release. Something changed in my local environment and I wasn't able to build a JAR that worked in the Spring App environment anymore.

# Additional Notes

# How to test the change?

See [README](https://github.com/DataDog/dd-serverless-azure-java-agent/blob/main/README.md)
