### PR TITLE
Bump dd-serverless-azure-java-agent Version to 0.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.datadoghq.com</groupId>
     <artifactId>dd-serverless-azure-java-agent</artifactId>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
     <packaging>jar</packaging>
     <name>Datadog Serverless Azure Java Agent</name>
 


### PR DESCRIPTION
# What does this PR do?

Bumps dd-serverless-azure-java-agent version to 0.2.0.

# Motivation

New mini agent release available in 0.7.0. So releasing dd-serverless-azure-java-agent version 0.2.0 with this new version.

# Additional Notes

# How to test the change?

See [README](https://github.com/DataDog/dd-serverless-azure-java-agent/blob/main/README.md)