### PR TITLE
Remove Spring dependency and relocate slf4j dependency

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: release
-          path: target/${{ github.ref_name }}-jar-with-dependencies.jar
+          path: target/${{ github.ref_name }}.jar
   release:
     name: Release
     needs: [build]
@@ -48,10 +48,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Download build artifact
         uses: actions/download-artifact@v4
-      - name: Rename artifacts
-        run: |
-          cp release/${{ github.ref_name }}-jar-with-dependencies.jar release/${{ github.ref_name }}.jar
-          cp release/${{ github.ref_name }}-jar-with-dependencies.jar release/dd-serverless-azure-java-agent.jar
+      - name: Copy latest artifact
+        run: cp release/${{ github.ref_name }}.jar release/dd-serverless-azure-java-agent.jar
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM mcr.microsoft.com/java/maven:8-zulu-debian10
+FROM azul/zulu-openjdk:8
+
+RUN apt-get -y update && apt-get -y install maven
 
 WORKDIR /app
 

--- a/build.sh
+++ b/build.sh
@@ -7,4 +7,4 @@ docker buildx build --platform linux/amd64 \
     . --load
 
 dockerId=$(docker create datadog/build-dd-serverless-java-agent:$VERSION)
-docker cp $dockerId:/app/target/dd-serverless-azure-java-agent-$VERSION-jar-with-dependencies.jar ./target/dd-serverless-azure-java-agent-$VERSION-jar-with-dependencies.jar
+docker cp $dockerId:/app/target/dd-serverless-azure-java-agent-$VERSION.jar ./target/dd-serverless-azure-java-agent-$VERSION.jar

--- a/pom.xml
+++ b/pom.xml
@@ -13,24 +13,8 @@
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>2.0.13</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.13</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-            <version>2.7.18</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>2.0.16</version>
         </dependency>
     </dependencies>
 
@@ -58,25 +42,33 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>single</goal>
+                            <goal>shade</goal>
                         </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.slf4j</pattern>
+                                    <shadedPattern>datadogserverless.slf4j</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <transformers>
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Premain-Class>com.datadog.ServerlessAzureAgent</Premain-Class>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <archive>
-                        <manifestEntries>
-                            <Premain-Class>com.datadog.ServerlessAzureAgent</Premain-Class>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
# What does this PR do?

Remove `spring-boot-starter-web` dependency and relocate slf4j.

# Motivation

Class conflicts when default JDBC framework is overridden by an app using this java agent.

https://datadoghq.atlassian.net/browse/SVLS-5748

```
[main] WARN org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext - Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanDefinitionStoreException: Failed to process import candidates for configuration class [com.ms.settlements.gsp.rulescatalog.SpringBootRulesCatalogApplication]; nested exception is java.lang.IllegalStateException: Could not evaluate condition on org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration$PooledDataSourceConfiguration due to com/zaxxer/hikari/HikariConfig not found. Make sure your own configuration does not rely on that class. This can also happen if you are @ComponentScanning a springframework package (e.g. if you put a @ComponentScan in the default package by mistake)
```

# Additional Notes

* Relocate `org.slf4j` to `datadogserverless.slf4j` to avoid class conflicts.
* Using the `maven-shade-plugin` to relocate dependencies and set the Premain-class. Previously just used the `maven-assembly-plugin` to set the Premain-class
* Changed build image to `azul/zulu-openjdk:8`
* Updated to latest versions of dependencies
* Updated release workflow to reference the renamed jar

# How to test the change?

See [README](https://github.com/DataDog/dd-serverless-azure-java-agent/blob/main/README.md)