### PR TITLE
Copy datadog-serverless-trace-mini-agent to temporary directory

### DIFF
--- a/src/main/java/com/datadog/ServerlessAzureAgent.java
+++ b/src/main/java/com/datadog/ServerlessAzureAgent.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.io.InputStream;
 import java.lang.instrument.Instrumentation;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,6 +13,7 @@ import org.slf4j.LoggerFactory;
 public class ServerlessAzureAgent {
     private static final Logger log = LoggerFactory.getLogger(ServerlessAzureAgent.class);
     private static final String fileName = "datadog-serverless-trace-mini-agent";
+    private static final String tempDirPath = "/tmp/datadog";
 
     public static void premain(String agentArgs, Instrumentation instrumentation) {
         log.info("Attempting to start {}", fileName);
@@ -21,7 +24,10 @@ public class ServerlessAzureAgent {
                 log.error("{} not found", fileName);
             }
 
-            File executableFile = new File(fileName);
+            Path tempDir = Paths.get(tempDirPath);
+            Files.createDirectories(tempDir);
+            File executableFile = tempDir.resolve(fileName).toFile();
+
             Files.copy(inputStream, executableFile.getAbsoluteFile().toPath(), StandardCopyOption.REPLACE_EXISTING);
             executableFile.setExecutable(true);
 


### PR DESCRIPTION
# What does this PR do?

Copies `datadog-serverless-trace-mini-agent` to temporary directory instead of root directory.

# Motivation

Avoid cluttering the root directory with Datadog binary.

# Additional Notes

# How to test the change?

See [README](https://github.com/DataDog/dd-serverless-azure-java-agent/blob/main/README.md)