### PR TITLE
Bump dd-serverless-azure-java-agent Version to 0.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.datadoghq.com</groupId>
     <artifactId>dd-serverless-azure-java-agent</artifactId>
-    <version>0.2.1</version>
+    <version>0.3.0</version>
     <packaging>jar</packaging>
     <name>Datadog Serverless Azure Java Agent</name>
 


### PR DESCRIPTION
# What does this PR do?

Bumps dd-serverless-azure-java-agent version to 0.3.0.

# Motivation

* Release of datadog-serverless-mini-agent v0.8.0
* Changes in below PRs
  - https://github.com/DataDog/dd-serverless-azure-java-agent/pull/5
  - https://github.com/DataDog/dd-serverless-azure-java-agent/pull/6

# Additional Notes

# How to test the change?

See [README](https://github.com/DataDog/dd-serverless-azure-java-agent/blob/main/README.md)