### PR TITLE
Add Support for Windows Azure Functions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ jobs:
 
           mkdir src/main/resources
           cp ./temp/datadog-serverless-agent/datadog-serverless-agent-linux-amd64/datadog-serverless-trace-mini-agent src/main/resources/datadog-serverless-trace-mini-agent
+          cp ./temp/datadog-serverless-agent/datadog-serverless-agent-windows-amd64/datadog-serverless-trace-mini-agent.exe src/main/resources/datadog-serverless-trace-mini-agent.exe
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build dd-serverless-azure-java-agent jar

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-datadog-serverless-trace-mini-agent
+datadog-serverless-trace-mini-agent*
 target

--- a/README.md
+++ b/README.md
@@ -1,21 +1,31 @@
 # Datadog Serverless Azure Java Agent
 
-Java agent used to start the Datadog Serverless Mini Agent. Intended for use with [Azure Spring Apps](https://azure.microsoft.com/en-us/products/spring-apps).
+Java agent used to start the Datadog Serverless Mini Agent. Intended for use with [Azure Spring Apps](https://azure.microsoft.com/en-us/products/spring-apps) and [Azure Functions](https://azure.microsoft.com/en-us/products/functions).
 
 # Getting Started
 
-- From the latest release, download `dd-serverless-azure-java-agent.jar` and upload it to your Azure Spring App in persistent storage.
-- Add the Datadog Serverless Azure Java Agent and Datadog Java Tracer as Java agents to your `JVM_OPTIONS`.
+- From the latest releases, download `dd-serverless-azure-java-agent.jar` and `dd-java-agent.jar` to your app:
+  * `wget -O dd-serverless-azure-java-agent.jar 'https://dtdg.co/latest-serverless-azure-java-agent'`
+  * `wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'`
+- Add the Datadog Serverless Azure Java Agent and Datadog Java Tracer as Java agents using the appropriate JVM Options environment variable:
+  * Azure Spring App
+    - `JVM_OPTIONS`
+  * Azure Function, Consumption Plan
+    - `languageWorkers__java__arguments`
+  * Azure Function, Premium/Dedicated Plan
+    - `JAVA_OPTS`
+  
 ```
--javaagent:/persistent/dd-serverless-azure-java-agent.jar -javaagent:/persistent/dd-java-agent.jar
+-javaagent:/path/to/dd-serverless-azure-java-agent.jar -javaagent:/path/to/dd-java-agent.jar
 ```
-- Set environment variables
-* `DD_API_KEY` = `<YOUR API KEY>`
-* `DD_SITE` = `datadoghq.com`
-* `DD_SERVICE` = `<SERVICE NAME>`
-* `DD_ENV` = `<ENVIRONMENT`
-* `DD_VERSION` = `<VERSION>`
-* `DD_TRACE_TRACER_METRICS_ENABLED` = `true`
+
+- Set Datadog environment variables
+  * `DD_API_KEY` = `<YOUR API KEY>`
+  * `DD_SITE` = `datadoghq.com`
+  * `DD_SERVICE` = `<SERVICE NAME>`
+  * `DD_ENV` = `<ENVIRONMENT`
+  * `DD_VERSION` = `<VERSION>`
+  * `DD_TRACE_TRACER_METRICS_ENABLED` = `true`
 
 # Contributing
 
@@ -25,7 +35,7 @@ Follow the instructions in the `dd-trace-java` repo to set up your Java environm
 
 ## Building the project
 
-Build the Datadog Serverless Mini Agent from [libdatadog](https://github.com/DataDog/libdatadog) and add the linux binary, `datadog-serverless-trace-mini-agent`, to `src/main/resources`.
+Build the Datadog Serverless Mini Agent from [libdatadog](https://github.com/DataDog/libdatadog) and add the binaries, `datadog-serverless-trace-mini-agent` and `datadog-serverless-trace-mini-agent.exe`, to `src/main/resources`.
 
 To build the project run:
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
             <resource>
                 <directory>src/main/resources</directory>
                 <includes>
-                    <include>datadog-serverless-trace-mini-agent</include>
+                    <include>datadog-serverless-trace-mini-agent*</include>
                 </includes>
             </resource>
         </resources>

--- a/src/main/java/com/datadog/ServerlessAzureAgent.java
+++ b/src/main/java/com/datadog/ServerlessAzureAgent.java
@@ -12,10 +12,33 @@ import org.slf4j.LoggerFactory;
 
 public class ServerlessAzureAgent {
     private static final Logger log = LoggerFactory.getLogger(ServerlessAzureAgent.class);
-    private static final String fileName = "datadog-serverless-trace-mini-agent";
-    private static final String tempDirPath = "/tmp/datadog";
+    private static final String os = System.getProperty("os.name").toLowerCase();
+
+    public static boolean isWindows() {
+        return os.contains("win");
+    }
+
+    public static boolean isLinux() {
+        return os.contains("linux");
+    }
 
     public static void premain(String agentArgs, Instrumentation instrumentation) {
+        final String fileName;
+        final String tempDirPath;
+
+        if (isWindows()) {
+            log.debug("Detected {}", os);
+            fileName = "datadog-serverless-trace-mini-agent.exe";
+            tempDirPath = "C:/local/Temp/datadog";
+        } else if (isLinux()) {
+            log.debug("Detected {}", os);
+            fileName = "datadog-serverless-trace-mini-agent";
+            tempDirPath = "/tmp/datadog";
+        } else {
+            log.error("Unsupported operating system {}", os);
+            return;
+        }
+
         log.info("Attempting to start {}", fileName);
 
         try (InputStream inputStream = ServerlessAzureAgent.class.getClassLoader()


### PR DESCRIPTION
# What does this PR do?

Start the Windows mini agent binary if in a Windows Azure Function environment. Otherwise, start the Linux binary if in an Azure Spring App or Linux Azure Function environment.

# Motivation

https://datadoghq.atlassian.net/browse/SVLS-5194

# Additional Notes

# How to test the change?

See [README](https://github.com/DataDog/dd-serverless-azure-java-agent/blob/main/README.md)