### PR TITLE
Remove Overlapping Resources and Dependency Reduced pom from Maven Shade Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,20 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.6.0</version>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>module-info.class</exclude>
+                                <exclude>META-INF/*</exclude>
+                                <exclude>META-INF/versions/**</exclude>
+                                <exclude>META-INF/services/**</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
# What does this PR do?

Prevents conflicts from `maven-shade-plugin`.

# Motivation

Address build warnings.

```
[INFO] Dependency-reduced POM written at: /Users/duncan.harvey/go/src/github.com/DataDog/dd-serverless-java-agent/dependency-reduced-pom.xml
[WARNING] dd-serverless-azure-java-agent-0.3.0.jar, slf4j-api-2.0.16.jar, slf4j-simple-2.0.16.jar define 1 overlapping resource: 
[WARNING]   - META-INF/MANIFEST.MF
[WARNING] slf4j-api-2.0.16.jar, slf4j-simple-2.0.16.jar define 2 overlapping class and resource: 
[WARNING]   - META-INF.versions.9.module-info
[WARNING]   - META-INF/LICENSE.txt
[WARNING] maven-shade-plugin has detected that some files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the file is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See https://maven.apache.org/plugins/maven-shade-plugin/
```

# Additional Notes

# How to test the change?

See [README](https://github.com/DataDog/dd-serverless-azure-java-agent/blob/main/README.md)