### PR TITLE
Bump dd-serverless-azure-java-agent Version to 0.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.datadoghq.com</groupId>
     <artifactId>dd-serverless-azure-java-agent</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
     <packaging>jar</packaging>
     <name>Datadog Serverless Azure Java Agent</name>
 


### PR DESCRIPTION
# What does this PR do?

Bumps dd-serverless-azure-java-agent version to 0.5.0.

# Motivation

Upcoming release

# Additional Notes

# How to test the change?

See [README](https://github.com/DataDog/dd-serverless-azure-java-agent/blob/main/README.md)