### PR TITLE
Add Permissions to Github Workflow to Create Release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,8 @@ jobs:
     name: Release
     needs: [build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       MINI_AGENT_VERSION: ${{ needs.build.outputs.mini-agent-version }}
     steps:


### PR DESCRIPTION
# What does this PR do?

Add permissions to Github Workflow to create release.

# Motivation

In order to comply with internal policies Github Workflows need specifically scoped permissions to create Github releases.

# Additional Notes

# How to test the change?

Pushed a test tag and confirmed that the release is created successfully.
